### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=datawhalechina/agentic-ai&type=date&legend=top-left)](https://www.star-history.com/#datawhalechina/agentic-ai&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=datawhalechina/agentic-ai&type=date&legend=top-left)](https://star-history.dera.page/#datawhalechina/agentic-ai&type=date&legend=top-left)
 
 
 ## License


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders. This change updates the chart link to a working source so the project's star history is visible again. No other changes are included.